### PR TITLE
Avoid flickering the main window when wsl is not installed.

### DIFF
--- a/src/mainwindow.pas
+++ b/src/mainwindow.pas
@@ -46,7 +46,6 @@ type
     IconListToolbar: TImageList;
     ToolBar1: TToolBar;
     ToolButtonRun: TToolButton;
-    procedure CheckIfWslIsInstalledExecute(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
     procedure FormHide(Sender: TObject);
@@ -235,18 +234,6 @@ begin
   end;
 end;
 
-procedure TWslGuiToolMainWindow.CheckIfWslIsInstalledExecute(Sender: TObject);
-begin
-  if not WslCommandLine.IsWslInstalled()
-  then begin
-    Application.MessageBox(
-      'WSL seems to be not installed!',
-      'Error',
-      MB_OK + MB_ICONERROR);
-    Application.Terminate;
-  end;
-end;
-
 procedure TWslGuiToolMainWindow.FormCreate(Sender: TObject);
 begin
   BackgroundProcessProgressBar := TBackgroundProcessProgressBar.Create(Self);
@@ -258,7 +245,6 @@ begin
 
   StatusbarImageIndex := -1;
   StatusbarMessage := '';
-  Self.CheckIfWslIsInstalledExecute(Sender);
 end;
 
 procedure TWslGuiToolMainWindow.FormDestroy(Sender: TObject);

--- a/src/wslguitool.lpr
+++ b/src/wslguitool.lpr
@@ -7,7 +7,7 @@ uses
   cthreads,
   {$ENDIF}{$ENDIF}
   Interfaces, // this includes the LCL widgetset
-  Forms, MainWindow, WslApi, WslCommandLine, WslRegistry, ApplicationInfo,
+  Forms, LCLType, MainWindow, WslApi, WslCommandLine, WslRegistry, ApplicationInfo,
   AboutWindow, DistributionPropertiesWindow, ImportDistributionWindow,
   RunCommandWithUserWindow, PromptWindow, BackgroundProcessProgressBar, ProcessResultDisplay;
 
@@ -15,9 +15,22 @@ uses
 
 begin
   RequireDerivedFormResource:=True;
+
   Application.Scaled:=True;
   Application.Initialize;
-  Application.CreateForm(TWslGuiToolMainWindow, WslGuiToolMainWindow);
-  Application.Run;
+
+  if WslCommandLine.IsWslInstalled() then
+  begin
+    Application.CreateForm(TWslGuiToolMainWindow, WslGuiToolMainWindow);
+    Application.Run;
+  end
+  else begin
+    Application.MessageBox(
+      'WSL seems to be not installed!',
+      'Error',
+      MB_OK + MB_ICONERROR
+    );
+    Application.Terminate;
+  end;
 end.
 


### PR DESCRIPTION
Checking whether wsl installed is in the main window, so the window must be created and shown anyway even if wsl is missing.

This patch moves the checking right in the application initialization before the window will be created and thus flickering of the main window is avoided.