### PR TITLE
Fix reading WSL distributions from the registry

### DIFF
--- a/src/wslregistry.pas
+++ b/src/wslregistry.pas
@@ -98,14 +98,20 @@ begin
 
     for i := 0 to DistributionsIdList.Count - 1 do
     begin
-      Distribution := LoadWslOneDistributionFromRegistryById(DistributionsIdList[i]);
+      try
+        Distribution := LoadWslOneDistributionFromRegistryById(DistributionsIdList[i]);
 
-      if Distribution.Id = DefaultDistribution
-      then begin
-        Distribution.IsDefault := true;
+        if Distribution.Id = DefaultDistribution
+        then begin
+          Distribution.IsDefault := true;
+        end;
+
+        Result.Add(Distribution);
+      except
+        on ERegistryException do begin
+          // TODO: should we log this type of exception ?
+        end;
       end;
-
-      Result.Add(Distribution);
     end;
 
     DistributionsIdList.Free;


### PR DESCRIPTION
On Windows 11 the WSL registry list contains `AppxInstallerCache` entry which produces an exception when reading the distribution version.
This fix catches such registry exception but lets continue reading the next entries.

The registry list looks like:
```
Lxss
  |- {dist-uuid-1}  <- distribution
  |- {dist-uuid-2}  <- distribution
  |- ....
  |- AppxInstallerCache <- empty
```